### PR TITLE
Bulk pseudocode fix

### DIFF
--- a/programming-fundamentals/chapter10.md
+++ b/programming-fundamentals/chapter10.md
@@ -41,16 +41,16 @@ Simply put, AI involves creating rules and algorithms that enable computers to p
 For example, think of a simple AI that plays tic-tac-toe:
 
 ```typescript
-function PlayTicTacToe(board)
-    while "empty space on the board exists" == True
-        if move == "lead to victory"
+function PlayTicTacToe(board):
+    while "empty space on the board exists" == True:
+        if move == "lead to victory":
             // If AI can win with this move, take it
             MAKE move
-            RETURN
-        else if move == "block opponent victory"
+            return
+        else if move == "block opponent victory":
             // If AI can block the opponent's victory, do it
             MAKE move
-            RETURN
+            return
         END if
     END while
 
@@ -73,21 +73,21 @@ A critical aspect of ML is that it relies on labeled data. This is like giving t
 Here's a simplified pseudocode example of how a machine could learn from labeled photos to tell the difference between cats and dogs:
 
 ```typescript
-function LearnFromPhotos(photoCollection)
-    while photo "left in" photoCollection
-        if photo is labeled 'cat'
+function LearnFromPhotos(photoCollection):
+    while photo "left in" photoCollection:
+        if photo is labeled 'cat':
             LearnFeatures('cat', photo)
-        else // Photo is labeled 'dog'
+        else: // Photo is labeled 'dog'
             LearnFeatures('dog', photo)
         END if
     END while
 END function
 
-function GuessAnimal(newPhoto)
-    if newPhoto "matches more features of" 'cat'
-        RETURN "This is probably a cat"
-    else
-        RETURN "This is probably a dog"
+function GuessAnimal(newPhoto):
+    if newPhoto "matches more features of" 'cat':
+        return "This is probably a cat"
+    else:
+        return "This is probably a dog"
     END if
 END function
 ```
@@ -125,15 +125,15 @@ Cybersecurity encompasses a range of subfields, each addressing different aspect
 Consider a scenario where you're trying to log into your social media account. Here's a pseudocode example to illustrate how a social media company might handle password authentication:
 
 ```typescript
-function CheckPassword(inputPassword)
+function CheckPassword(inputPassword):
     realPassword = "secret123"  // This is the correct password
     attemptCount = 0            // Start counting attempts
 
-    while attemptCount < 3
-        if inputPassword == realPassword
+    while attemptCount < 3:
+        if inputPassword == realPassword:
             Print("Welcome! You're in.")
             EXIT LOOP  // Stop checking since the password is correct
-        else
+        else:
             Print("Oops! Wrong password. Try again.")
             attemptCount = attemptCount + 1
             // Ask for the password again
@@ -141,7 +141,7 @@ function CheckPassword(inputPassword)
         END if
     END while
 
-    if attemptCount == 3
+    if attemptCount == 3:
         Print("Sorry, no more tries allowed.")
     END if
 END function
@@ -173,20 +173,20 @@ One of the core concepts in game development is the game loop, a continuous cycl
 Let's look at a basic pseudocode example for a simple 2D game loop, similar to classic games like Super Mario Bros:
 
 ```typescript
-function RunGame()
+function RunGame():
     gameIsRunning = True
     playerScore = 0
 
-    while gameIsRunning == True
+    while gameIsRunning == True:
         // Check for player input (like movement or actions)
         playerInput = GetPlayerInput()
 
         // Update the game state based on player input and other factors
-        if playerInput == "jump"
+        if playerInput == "jump":
             jump()
-        else if playerInput == "move left"
+        else if playerInput == "move left":
             moveLeft()
-        else if playerInput == "move right"
+        else if playerInput == "move right":
             moveRight()
         END if
 
@@ -197,7 +197,7 @@ function RunGame()
         RenderGameScreen()
 
         // Check if the player wants to exit the game
-        if playerInput == "exit"
+        if playerInput == "exit":
             gameIsRunning = False
         END if
     END while
@@ -205,27 +205,27 @@ function RunGame()
     Print("Game Over! Your score: " + playerScore)
 END function
 
-function GetPlayerInput()
+function GetPlayerInput():
     // Code to get the player's current action
 END function
 
-function Jump()
+function Jump():
     // Code for the jump action
 END function
 
-function MoveLeft()
+function MoveLeft():
     // Code for moving left
 END function
 
-function MoveRight()
+function MoveRight():
     // Code for moving right
 END function
 
-function UpdateScore(score)
+function UpdateScore(score):
     // Code to update the player's score
 END function
 
-function RenderGameScreen()
+function RenderGameScreen():
     // Code to display the game state on the screen
 END function
 ```
@@ -243,27 +243,27 @@ At the core of robotics is the programming that controls how these machines oper
 Here's a simple pseudocode example, similar to the algorithm a robotic vacuum cleaner might use to navigate around obstacles:
 
 ```typescript
-function NavigateRoom()
-    while not atDestination
-        if ObstacleDetected()
+function NavigateRoom():
+    while NOT atDestination:
+        if ObstacleDetected():
             AvoidObstacle()
-        else
+        else:
             MoveForward()
         END if
     END while
     Print("Destination reached!")
 END function
 
-function ObstacleDetected()
+function ObstacleDetected():
     // Code to detect if there is an obstacle in front of the robot
     // Returns true if an obstacle is detected, false otherwise
 END function
 
-function AvoidObstacle()
+function AvoidObstacle():
     // Code for the robot to change direction or take action to avoid the obstacle
 END function
 
-function MoveForward()
+function MoveForward():
     // Code to move the robot forward
 END function
 ```
@@ -285,27 +285,27 @@ Here's a simple pseudocode example that mirrors this interaction in web developm
 
 ```typescript
 // Client-Side Code
-function RequestWebPage(url)
+function RequestWebPage(url):
     Print("Requesting webpage from: " + url)
     response = SendRequestToServer(url) // Function defined below
-    if response != "Error"
+    if response != "Error":
         DisplayWebPage(response)
-    else
+    else:
         Print("Failed to load webpage.")
     END if
 END function
 
 // Server-Side Code
-function SendRequestToServer(url)
-    if url "exists in" server
+function SendRequestToServer(url):
+    if url "exists in" server:
         pageContent = GetPageContent(url) // Function defined below
         return pageContent
-    else
+    else:
         return "Error: Page not found"
     END if
 END function
 
-function GetPageContent(url)
+function GetPageContent(url):
     // Code to retrieve the webpage content based on the URL
     // Returns the HTML/CSS/JS content of the page
 END function

--- a/programming-fundamentals/chapter3.md
+++ b/programming-fundamentals/chapter3.md
@@ -154,8 +154,6 @@ In both cases, the underlying principle is evaluating the accuracy or truthfulne
 
 When programming real-world applications, we use variables like *'raining'* or *'temperature'* to symbolize and manage real-world data. Our decision-making constructs and logical operators interact with these variables in the same way they would with pure numbers.
 
-<!-- [4-part Illustration: 1. 3>2 (True), 2. 4>4 (False), 3. raining (True), 4. not raining (False)] -->
-
 This dynamic nature of variables lets our programs react and make decisions based on the current situation or data, whether that data represents numbers, weather conditions, user inputs, or any other conceivable scenario.
 
 With this understanding, we can now delve into real-world problems like deciding whether to hold an outdoor event based on the weather forecast.
@@ -181,7 +179,7 @@ Next, we must decide what to do based on the number's value. This is where the *
 If the number is greater than zero, we can say it's positive:
 
 ```typescript
-IF number > 0 THEN
+if number > 0 THEN:
     PRINT "The number is positive."
 ```
 
@@ -190,21 +188,21 @@ But what if it's not? We need another check, and that's where **else if** proves
 If the number is less than zero, it's negative:
 
 ```typescript
-ELSE IF number < 0 THEN
+else if number < 0 THEN:
     PRINT "The number is negative."
 ```
 
 Lastly, if the number isn't positive or negative, it must be zero. That's where **else** comes in. It's our catch-all for "if none of the above conditions are met, do this":
 
 ```typescript
-ELSE
+else:
     PRINT "The number is zero."
 ```
 
 And, to neatly conclude our decision-making constructs, we use:
 
 ```typescript
-END IF
+END if
 ```
 
 Putting it all together, we have
@@ -212,13 +210,13 @@ Putting it all together, we have
 ```typescript
 INPUT number
 
-IF number > 0 THEN
+if number > 0 THEN:
     PRINT "The number is positive."
-ELSE IF number < 0 THEN
+else if number < 0 THEN:
     PRINT "The number is negative."
-ELSE
+else:
     PRINT "The number is zero."
-END IF
+END if
 ```
 
 By outlining logic in pseudocode, transitioning to actual coding in any programming language becomes a smoother process, as the core logic remains consistent.
@@ -230,13 +228,13 @@ Without going into all the steps, here is the final pseudocode.
 ```typescript
 INPUT number
 
-IF number == 0 THEN
+if number == 0 THEN:
     PRINT "The number is zero."
-ELSE IF number > 0 THEN
+else if number > 0 THEN:
     PRINT "The number is positive."
-ELSE
+else:
     PRINT "The number is negative."
-END IF
+END if
 ```
 
 There are multiple ways to solve most problems, depending on the order in which you evaluate the conditions.
@@ -262,7 +260,7 @@ We want to check if it's NOT raining. Here's how we can understand the NOT raini
 In pseudocode:
 
 ```typescript
-IF NOT raining
+if NOT raining:
 ```
 
 **Evaluating Temperature:**
@@ -275,9 +273,9 @@ temperature >= 18 AND temperature <= 30
 Combining both conditions, our complete decision-making pseudocode becomes:
 
 ```typescript
-IF NOT raining AND (temperature >= 18 AND temperature <= 30):
+if NOT raining AND (temperature >= 18 AND temperature <= 30):
     proceed_with_event
-ELSE
+else:
     reschedule_event
 ```
 

--- a/programming-fundamentals/chapter6.md
+++ b/programming-fundamentals/chapter6.md
@@ -20,7 +20,7 @@ questions:
       FUNCTION ServeFood(guestName, , )
           // Determine the food to serve based on the guest's name, preference, and any dietary restrictions
           // Once the appropriate food is selected, the robot serves it to the guest
-          RETURN "Food served to " + guestName
+          return "Food served to " + guestName
       END FUNCTION
   - user-profile: |
       Design a function named DisplayProfile(userName, userAge) that takes in the user's name and age and returns a profile summary.
@@ -181,33 +181,33 @@ Let's illustrate with two pseudocode examples:
 **1. Returning a status message:**
 
 ```typescript
-FUNCTION AssembleFuselage(size, numberOfWindows)
+function AssembleFuselage(size, numberOfWindows)
     // The fuselage gets assembled based on the size and number of windows.
     
     // Once done, a status message is sent back.
-    RETURN "Fuselage Assembly Complete"
-END FUNCTION
+    return "Fuselage Assembly Complete"
+END function
 ```
 
 In this case:
 
-- `RETURN`: This keyword indicates that the function is providing an outcome after completing its task.
+- `return`: This keyword indicates that the function is providing an outcome after completing its task.
 - `"Fuselage Assembly Complete"`: This is the message the function returns. It's equivalent to the assembly team announcing their completion.
 
 **2. Returning the actual assembled fuselage:**
 
 ```typescript
-FUNCTION AssembleFuselage(size, numberOfWindows)
+function AssembleFuselage(size, numberOfWindows)
     // The fuselage gets assembled based on the size and number of windows.
     
     // Once done, the assembled fuselage is returned for further use.
-    RETURN assembledFuselage
-END FUNCTION
+    return assembledFuselage
+END function
 ```
 
 In this scenario:
 
-- `RETURN`: Indicates that the function is providing the result of its task.
+- `return`: Indicates that the function is providing the result of its task.
 - `assembledFuselage`: Represents the finished plane part that's being returned. Think of this as the actual fuselage being presented for inspection or integration.
 
 > Note: Again, notice the indentation of the body of the functions. This indicates that those lines of code are inside the function, and it visually separates the body of the function from the rest of the code, making the code structure clear and readable.
@@ -221,37 +221,37 @@ When constructing an airplane, for the sake of this example, we'll consider that
 **Fuselage Assembly:** The department responsible for assembling the fuselage. Parameters like its size and the number of windows are crucial to this process.
 
 ```typescript
-FUNCTION AssembleFuselage(fuselageSize, numberOfWindows)
+function AssembleFuselage(fuselageSize, numberOfWindows)
     // Steps to assemble the fuselage
-    RETURN "Fuselage Assembly Complete"
-END FUNCTION
+    return "Fuselage Assembly Complete"
+END function
 ```
 
 **Wing Assembly:** The design and structure of the wings are determined by the specific model of the airplane. Different types may necessitate varying wing configurations.
 
 ```typescript
-FUNCTION AssembleWings(typeOfWing)
+function AssembleWings(typeOfWing)
     // Steps to assemble the chosen type of wing
-    RETURN "Wings Assembly Complete"
-END FUNCTION
+    return "Wings Assembly Complete"
+END function
 ```
 
 **Engine Installation:** The number of engines an airplane carries depends on its size and purpose. A cargo plane might require more engines than a small commercial jet, for instance.
 
 ```typescript
-FUNCTION InstallEngines(numberOfEngines)
+function InstallEngines(numberOfEngines)
     // Steps to install the specified number of engines
-    RETURN "Engine Installation Complete"
-END FUNCTION
+    return "Engine Installation Complete"
+END function
 ```
 
 **Cockpit Assembly:** The cockpit's electronic systems are standardized across various airplane models. Given this uniformity, assembling the cockpit doesn't require specific input parameters.
 
 ```typescript
-FUNCTION AssembleCockpit()
+function AssembleCockpit()
     // Steps to set up the chosen type of controls
-    RETURN "Cockpit Assembly Complete"
-END FUNCTION
+    return "Cockpit Assembly Complete"
+END function
 ```
 
 ### Assembling the Entire Airplane
@@ -259,13 +259,13 @@ END FUNCTION
 With the above modules, the main assembly function would be:
 
 ```typescript
-FUNCTION AssembleAirplane(fuselageSize, numberOfWindows, typeOfWing, numberOfEngines)
+function AssembleAirplane(fuselageSize, numberOfWindows, typeOfWing, numberOfEngines)
     AssembleFuselage(fuselageSize, numberOfWindows)
     AssembleWings(typeOfWing)
     InstallEngines(numberOfEngines)
     AssembleCockpit()
-    RETURN "Airplane Assembly Complete"
-END FUNCTION
+    return "Airplane Assembly Complete"
+END function
 ```
 
 > Note: Notice how the call to `AssembleCockpit` did not require any arguments to be passed to the function. This is because `AssembleCockpit` doesn't take any input, and so the parentheses are left empty.
@@ -285,25 +285,25 @@ Break down the process of organizing a birthday party into smaller, more managea
 Pseudocode:
 
 ```typescript
-FUNCTION SendInvitations(listOfFriends)
+function SendInvitations(listOfFriends)
     // Steps to send out invitations to friends on the list
-    RETURN "Invitations Sent"
-END FUNCTION
+    return "Invitations Sent"
+END function
 
-FUNCTION OrderCake(cakeType, caseSize)
+function OrderCake(cakeType, caseSize)
     // Steps to order a specific type of cake
-    RETURN "Cake Ordered"
-END FUNCTION
+    return "Cake Ordered"
+END function
 
-FUNCTION DecorateVenue(theme)
+function DecorateVenue(theme)
     // Steps to decorate the venue based on the chosen theme
-    RETURN "Venue Decorated"
-END FUNCTION
+    return "Venue Decorated"
+END function
 
-FUNCTION ArrangeMusic(playlist)
+function ArrangeMusic(playlist)
     // Steps to set up music based on the chosen playlist
-    RETURN "Music Arranged"
-END FUNCTION
+    return "Music Arranged"
+END function
 ```
 
 Since the question only asked us to "design the functions", this means that we don't need to make the actual function calls and complete the task of actually organizing a birthday party. It's like creating an action plan without carrying out the actions.
@@ -321,20 +321,20 @@ Write pseudocode for the following three functions, and then make function calls
 Pseudocode:
 
 ```typescript
-FUNCTION GreetUser(userName)
+function GreetUser(userName)
     // Greet the user by name
-    RETURN "Hello, " + userName + "!"
-END FUNCTION
+    return "Hello, " + userName + "!"
+END function
 
-FUNCTION DisplayDate()
+function DisplayDate()
     // Show today's date
-    RETURN todaysDate
-END FUNCTION
+    return todaysDate
+END function
 
-FUNCTION RecommendMovie(favoriteMovie)
+function RecommendMovie(favoriteMovie)
     // Suggest a movie for the user to watch based on his favorite movie
-    RETURN topRecommendation
-END FUNCTION
+    return topRecommendation
+END function
 ```
 
 The function calls of these function would look like this:
@@ -355,4 +355,4 @@ Hello, John!
 Murder on the Orient Express
 ```
 
-It is important to note that the function `DisplayDate` does not need any input in order to display today's date. THat is why, in its function definition, we do not include any parameters, and similarly, when calling the function, we do not pass any arguments.
+It is important to note that the function `DisplayDate` does not need any input in order to display today's date. That is why, in its function definition, we do not include any parameters, and similarly, when calling the function, we do not pass any arguments.

--- a/programming-fundamentals/chapter6.md
+++ b/programming-fundamentals/chapter6.md
@@ -7,9 +7,9 @@ questions:
   - birthday-song: |
       The "Happy Birthday" song has a repetitive structure. Given the function provided below:
 
-      FUNCTION HappyBDay()
+      function HappyBDay():
           DISPLAY "Happy birthday to you!"
-      END FUNCTION    
+      END function    
 
       Construct a program that utilizes this function to display the complete "Happy Birthday" song for an individual named John.
   - party-food: |
@@ -17,11 +17,11 @@ questions:
 
       Complete the function definition provided below. Afterwards, demonstrate its usage by calling it three times with details for three different guests.
 
-      FUNCTION ServeFood(guestName, , )
+      function ServeFood(guestName, , ):
           // Determine the food to serve based on the guest's name, preference, and any dietary restrictions
           // Once the appropriate food is selected, the robot serves it to the guest
           return "Food served to " + guestName
-      END FUNCTION
+      END function
   - user-profile: |
       Design a function named DisplayProfile(userName, userAge) that takes in the user's name and age and returns a profile summary.
 ---
@@ -117,21 +117,21 @@ In programming, it's the same story. The programmer (general manager) needs to p
 For our fuselage assembly example, the code might look like this:
 
 ```typescript
-FUNCTION AssembleFuselage(size, numberOfWindows)
+function AssembleFuselage(size, numberOfWindows):
     // Here the fuselage gets assembled.
-END FUNCTION
+END function
 ```
 
 Breaking this down:
 
-- `FUNCTION`: This is a keyword indicating that we're defining a new function. Think of it as announcing, "Hey, we're setting up a new section of the assembly line here!"
+- `function`: This is a keyword indicating that we're defining a new function. Think of it as announcing, "Hey, we're setting up a new section of the assembly line here!"
 - `AssembleFuselage`: This is the name of the function, much like naming the "fuselage assembly" section. By using this name in our code, we can instruct the function to start its task, just as a project manager would say *"Hey Fuselage-Assembly team, get to work!"*
 - `(size, numberOfWindows)`: Inside these parentheses, we have our parameters – the essential details the function needs. In this case, the two parameters are:
 - `size`: This parameter expects a value that indicates the size of the airplane, like "small", "medium", or "large".
 - `numberOfWindows`: This parameter expects a number, indicating how many windows the fuselage should have.
 Think of these parameters as the instruction manual or blueprint for the fuselage assembly team. Without these specifics, the team won't know how to proceed.
 - `// Here the fuselage gets assembled.`: This is a comment in the pseudocode. It doesn't affect the functionality but is a note to anyone reading the code (or for our analogy, a reminder for the assembly team) about what happens in this section of the function. In a real code setting, this is where the steps or operations to assemble the fuselage would be detailed.
-- `END FUNCTION`: This keyword indicates the function's conclusion. It's a signal that the process defined in this function is complete. Think of it as the signal that the fuselage assembly job is complete.
+- `END function`: This keyword indicates the function's conclusion. It's a signal that the process defined in this function is complete. Think of it as the signal that the fuselage assembly job is complete.
 
 > Note: You might notice that the comment in the pseudocode is indented (moved a few spaces to the right). This indentation is a convention in programming to show that a piece of code belongs to or is "inside" a specific section, in this case, the AssembleFuselage function.
 
@@ -181,7 +181,7 @@ Let's illustrate with two pseudocode examples:
 **1. Returning a status message:**
 
 ```typescript
-function AssembleFuselage(size, numberOfWindows)
+function AssembleFuselage(size, numberOfWindows):
     // The fuselage gets assembled based on the size and number of windows.
     
     // Once done, a status message is sent back.
@@ -197,7 +197,7 @@ In this case:
 **2. Returning the actual assembled fuselage:**
 
 ```typescript
-function AssembleFuselage(size, numberOfWindows)
+function AssembleFuselage(size, numberOfWindows):
     // The fuselage gets assembled based on the size and number of windows.
     
     // Once done, the assembled fuselage is returned for further use.
@@ -221,7 +221,7 @@ When constructing an airplane, for the sake of this example, we'll consider that
 **Fuselage Assembly:** The department responsible for assembling the fuselage. Parameters like its size and the number of windows are crucial to this process.
 
 ```typescript
-function AssembleFuselage(fuselageSize, numberOfWindows)
+function AssembleFuselage(fuselageSize, numberOfWindows):
     // Steps to assemble the fuselage
     return "Fuselage Assembly Complete"
 END function
@@ -230,7 +230,7 @@ END function
 **Wing Assembly:** The design and structure of the wings are determined by the specific model of the airplane. Different types may necessitate varying wing configurations.
 
 ```typescript
-function AssembleWings(typeOfWing)
+function AssembleWings(typeOfWing):
     // Steps to assemble the chosen type of wing
     return "Wings Assembly Complete"
 END function
@@ -239,7 +239,7 @@ END function
 **Engine Installation:** The number of engines an airplane carries depends on its size and purpose. A cargo plane might require more engines than a small commercial jet, for instance.
 
 ```typescript
-function InstallEngines(numberOfEngines)
+function InstallEngines(numberOfEngines):
     // Steps to install the specified number of engines
     return "Engine Installation Complete"
 END function
@@ -248,7 +248,7 @@ END function
 **Cockpit Assembly:** The cockpit's electronic systems are standardized across various airplane models. Given this uniformity, assembling the cockpit doesn't require specific input parameters.
 
 ```typescript
-function AssembleCockpit()
+function AssembleCockpit():
     // Steps to set up the chosen type of controls
     return "Cockpit Assembly Complete"
 END function
@@ -259,7 +259,7 @@ END function
 With the above modules, the main assembly function would be:
 
 ```typescript
-function AssembleAirplane(fuselageSize, numberOfWindows, typeOfWing, numberOfEngines)
+function AssembleAirplane(fuselageSize, numberOfWindows, typeOfWing, numberOfEngines):
     AssembleFuselage(fuselageSize, numberOfWindows)
     AssembleWings(typeOfWing)
     InstallEngines(numberOfEngines)
@@ -285,22 +285,22 @@ Break down the process of organizing a birthday party into smaller, more managea
 Pseudocode:
 
 ```typescript
-function SendInvitations(listOfFriends)
+function SendInvitations(listOfFriends):
     // Steps to send out invitations to friends on the list
     return "Invitations Sent"
 END function
 
-function OrderCake(cakeType, caseSize)
+function OrderCake(cakeType, caseSize):
     // Steps to order a specific type of cake
     return "Cake Ordered"
 END function
 
-function DecorateVenue(theme)
+function DecorateVenue(theme):
     // Steps to decorate the venue based on the chosen theme
     return "Venue Decorated"
 END function
 
-function ArrangeMusic(playlist)
+function ArrangeMusic(playlist):
     // Steps to set up music based on the chosen playlist
     return "Music Arranged"
 END function
@@ -321,17 +321,17 @@ Write pseudocode for the following three functions, and then make function calls
 Pseudocode:
 
 ```typescript
-function GreetUser(userName)
+function GreetUser(userName):
     // Greet the user by name
     return "Hello, " + userName + "!"
 END function
 
-function DisplayDate()
+function DisplayDate():
     // Show today's date
     return todaysDate
 END function
 
-function RecommendMovie(favoriteMovie)
+function RecommendMovie(favoriteMovie):
     // Suggest a movie for the user to watch based on his favorite movie
     return topRecommendation
 END function

--- a/programming-fundamentals/chapter7.md
+++ b/programming-fundamentals/chapter7.md
@@ -53,10 +53,10 @@ To solve this, it's important to understand the relationship between Celsius and
 **Pseudocode:**
 
 ```typescript
-FUNCTION ConvertToFahrenheit(celsius):
+function ConvertToFahrenheit(celsius):
     fahrenheit = celsius * 9/5 + 32
-    RETURN fahrenheit
-END FUNCTION
+    return fahrenheit
+END function
 ```
 
 **Explanation:**
@@ -84,14 +84,15 @@ To figure out if a number is even or odd using loops, we'll subtract 2 from the 
 **Pseudocode:**
 
 ```typescript
-FUNCTION IsEvenOrOdd(number):
-    WHILE number >= 2:
+function IsEvenOrOdd(number):
+    while number >= 2:
         number = number - 2
-    IF number == 0:
-        RETURN "Even"
-    ELSE:
-        RETURN "Odd"
-END FUNCTION
+
+    if number == 0:
+        return "Even"
+    else:
+        return "Odd"
+END function
 ```
 
 **Explanation:**
@@ -130,19 +131,19 @@ number2 = INPUT
 PRINT "Enter operation (+, -, *, /): "
 operation = INPUT
 
-IF operation == "+":
+if operation == "+":
     result = number1 + number2
     PRINT result
-ELIF operation == "-":
+else if operation == "-":
     result = number1 - number2
     PRINT result
-ELIF operation == "*":
+else if operation == "*":
     result = number1 * number2
     PRINT result
-ELIF operation == "/":
+else if operation == "/":
     result = number1 / number2
     PRINT result
-ELSE:
+else:
     PRINT "Unrecognized operation"
 ```
 
@@ -167,26 +168,26 @@ We'll set a predefined secret number, and then use a `WHILE` loop to repeatedly 
 **Pseudocode:**
 
 ```typescript
-FUNCTION Feedback(guess, secret_number):
-    IF guess < secret_number:
-        RETURN "Your guess is too low."
-    ELSE IF guess > secret_number:
-        RETURN "Your guess is too high."
-    ELSE:
-        RETURN "Congratulations! You've guessed the secret number."
-END FUNCTION
+function Feedback(guess, secret_number):
+    if guess < secret_number:
+        return "Your guess is too low."
+    else if guess > secret_number:
+        return "Your guess is too high."
+    else:
+        return "Congratulations! You've guessed the secret number."
+END function
 
 secret_number = 7
 guess = 0
 
 PRINT "Guess the secret number between 1 and 10."
 
-WHILE guess != secret_number:
+while guess != secret_number:
     PRINT "Enter your guess:"
     guess = INPUT
     message = Feedback(guess, secret_number)
     PRINT message
-END WHILE
+END while
 ```
 
 **Explanation:**
@@ -231,19 +232,19 @@ Design a function that represents the process adopted by the engine installation
 **Answer:**
 
 ```typescript
-FUNCTION InstallEngines(wings, numberOfEngines)
+function InstallEngines(wings, numberOfEngines):
     enginesInstalled = 0
     enginesPerWing = numberOfEngines / 2
 
-    WHILE enginesInstalled < numberOfEngines
-        IF enginesInstalled == enginesPerWing + 1
+    while enginesInstalled < numberOfEngines:
+        if enginesInstalled == enginesPerWing + 1:
             switch_to_other_wing
         install_engine // Steps to install engine
         enginesInstalled = enginesInstalled + 1
-    END WHILE
+    END while
     
-    RETURN "Engine Installation Complete"
-END FUNCTION
+    return "Engine Installation Complete"
+END function
 ```
 
 1. **Function Declaration:** The algorithm starts with the declaration of the `InstallEngines` function. This function models the procedure of attaching engines to an airplane's wings. It accepts two parameters: `wings`, symbolizing the airplane's wings, and `numberOfEngines`, indicating the total number of engines to be installed.
@@ -266,17 +267,17 @@ Design a pseudocode algorithm that calculates and displays the eligible discount
 **Answer:**
 
 ```typescript
-FUNCTION CalculateDiscount(age, membershipDuration)
+function CalculateDiscount(age, membershipDuration):
     discount = 0
 
-    IF age < 20 AND membershipDuration == 0
+    if age < 20 AND membershipDuration == 0:
         discount = 10
-    ELSE IF age >= 55 AND membershipDuration >= 5
+    else if age >= 55 AND membershipDuration >= 5:
         discount = 15
-    END IF
+    END if
 
-    RETURN discount
-END FUNCTION
+    return discount
+END function
 
 // Main Program
 PRINT "Enter your age: "

--- a/programming-fundamentals/chapter8.md
+++ b/programming-fundamentals/chapter8.md
@@ -41,7 +41,7 @@ These are the easiest to spot and fix. They happen when you misspell a command o
 **Incorrect Pseudocode:**
 
 ```typescript
-IF x > 10
+if x > 10
     PRIT "X is a big number!"
 ```
 
@@ -50,7 +50,7 @@ Can you spot the mistake?
 **Corrected Pseudocode:**
 
 ```typescript
-IF x > 10
+if x > 10
     PRINT "X is a big number!"
 ```
 
@@ -61,9 +61,9 @@ These can be trickier. Logic errors happen when your pseudocode doesn't do what 
 **Incorrect Pseudocode:**
 
 ```typescript
-IF x < 10
+if x < 10
     PRINT "X is a big number!"
-ELSE
+else
     PRINT "X is a small number!"
 ```
 
@@ -72,9 +72,9 @@ The messages are mixed up! If x is less than 10, it should say that it's a small
 **Corrected Pseudocode:**
 
 ```typescript
-IF x < 10
+if x < 10
     PRINT "X is a small number!"
-ELSE
+else
     PRINT "X is a big number!"
 ```
 
@@ -110,11 +110,11 @@ Spotting errors in your code doesn't have to be overwhelming. With a few smart s
 To illustrate, let's consider a simple piece of pseudocode:
 
 ```typescript
-IF temperature > 30
+if temperature > 30
     PRINT "It's hot outside!"
-ELIF temperature > 20 and temperature < 30
+else if temperature > 20 and temperature < 30
     PRINT "It's warm outside!"
-ELSE
+else
     PRINT "It's a cold day."
 ```
 
@@ -124,7 +124,7 @@ Using our strategies:
 
 **Check for Completeness and Edge Cases:** Each statement appears to address different temperature ranges, but is there any range missing? What happens if the temperature is exactly 20? What about 30?
 
-**Simplify Complex Statements:** The `ELIF` statement uses 'and', a logical operator that requires both conditions to be true. Make sure this logic correctly includes all intended values, especially at the boundaries.
+**Simplify Complex Statements:** The `else if` statement uses 'and', a logical operator that requires both conditions to be true. Make sure this logic correctly includes all intended values, especially at the boundaries.
 
 **Peer Review:** A classmate might not spot the boundary issue immediately, but a discussion could lead to questions about temperatures at the edge cases.
 
@@ -140,11 +140,11 @@ Your friend wrote the following code:
 
 ```typescript
 x = INPUT
-IF x < 10
+if x < 10
     PRINT "x is less than 10"
-ELSE IF x < 5
+else if x < 5
     PRINT "x is less than 5"
-ELSE
+else
     PRINT "x is not less than 10 and 5"
 ```
 
@@ -162,17 +162,17 @@ Let's run through some numbers:
 - **Exactly 5:** It prints "x is less than 10". This is correct.
 - **Below 5 (e.g., 3):** It prints "x is less than 10" instead of printing "x is less than 5", which is what we actually want. This is a case that the code fails to handle correctly.
 
-The flaw lies in the sequence of the conditions. When we input a number, for example, 3, the program first checks if `x < 10`. Since 3 is indeed less than 10, the program outputs "x is less than 10" and bypasses the subsequent conditions. As a result, the second condition `ELSE IF x < 5` is never executed, which means the program will never print "x is less than 5", even though it's accurate.
+The flaw lies in the sequence of the conditions. When we input a number, for example, 3, the program first checks if `x < 10`. Since 3 is indeed less than 10, the program outputs "x is less than 10" and bypasses the subsequent conditions. As a result, the second condition `else if x < 5` is never executed, which means the program will never print "x is less than 5", even though it's accurate.
 
 The code should be rearranged so that it checks for the smaller value first. Here's a corrected version:
 
 ```typescript
 x = INPUT
-IF x < 5
+if x < 5
     PRINT "x is less than 5"
-ELSE IF x < 10
+else if x < 10
     PRINT "x is less than 10"
-ELSE
+else
     PRINT "x is not less than 10 and 5"
 ```
 
@@ -184,10 +184,10 @@ Your friend was asked to write a program that will count numbers from 1 to 10. T
 
 ```typescript
 i = 1         // Initialize variable i
-WHILE i < 10
+while i < 10
     PRINT i   // Display i onto the screen
     i = i + 1 // Increment i by 1
-END WHILE
+END while
 ```
 
 Comment on this code. Does it do what it is intended to do? What would you change, if anything?
@@ -207,10 +207,10 @@ To correct this, we can change the loop's condition to `i <= 10` so that it incl
 
 ```typescript
 i = 1         // Initialize variable i
-WHILE i <= 10
+while i <= 10
     PRINT i   // Display i onto the screen
     i = i + 1 // Increment i by 1
-END WHILE
+END while
 ```
 
 Now, if you mentally run through the code again, you'll see that it counts all the way up to 10, fixing the original issue and ensuring that the program works as intended.

--- a/programming-fundamentals/chapter9.md
+++ b/programming-fundamentals/chapter9.md
@@ -42,7 +42,7 @@ In some of the previous chapters, we've touched upon some good coding practices 
 Good naming is like giving clear, easy-to-follow instructions. When naming functions, we use verbs to describe actions, making it obvious what the function does. So is this good enough?
 
 ```typescript
-function DoThing()
+function DoThing():
     ...
 END function
 ```
@@ -52,7 +52,7 @@ No, because what this function does just by looking at its name is anyone's gues
 Instead, you should call it something like:
 
 ```typescript
-function CalculateTotalScore()
+function CalculateTotalScore():
     ...
 END function
 ```
@@ -78,7 +78,7 @@ How you structure and format your code can greatly influence how easy it is to r
 Just like paragraphs in a story, code needs to be organized with proper spacing and indentation to tell the computer (and our friends) what steps to follow and in what order. Indentation helps to show which pieces of code are connected. For example, everything inside a loop should be indented one level deeper:
 
 ```typescript
-function PrepareTea(numOfGuests)
+function PrepareTea(numOfGuests):
     i = 0
     while i < numOfGuests:
         AddWater()
@@ -94,7 +94,7 @@ Notice how the actions inside the for loop (adding water and steeping the tea) a
 Think of variables like ingredients in a recipe. You want to lay them all out before you start cooking. By grouping related variables at the start, you make your "recipe" easier to follow. Here's an example:
 
 ```typescript
-function BakeCake()
+function BakeCake():
     eggs = 3
     sugar = "1 cup"
     flour = "2 cups"
@@ -112,10 +112,10 @@ All the "ingredients" are listed at the top, so it's clear what we need to bake 
 When writing a story, we use paragraphs to separate ideas; in coding, we use blank lines to break up our code into sections. Each part does something different, like setting up the game, playing a round, or ending the game:
 
 ```typescript
-function PlayGame()
+function PlayGame():
     SetupGame()
 
-    while not gameOver
+    while not gameOver:
         PlayRound()
     END while
     
@@ -129,9 +129,9 @@ When we write stories, if we have too many stories within stories, it can become
 
 ```typescript
 // Try to avoid this
-if conditionA
-    if conditionB
-        if conditionC
+if conditionA:
+    if conditionB:
+        if conditionC:
             // Code here is deeply nested 
             //and harder to read.
         END if
@@ -140,7 +140,7 @@ END if
 
 
 // Better approach
-if conditionA AND conditionB AND conditionC
+if conditionA AND conditionB AND conditionC:
     // Code here is easier to understand.
 END if
 ```
@@ -151,14 +151,14 @@ Just like we don't want to repeat the same story over and over again, we don't w
 
 ```typescript
 // Instead of this
-if conditionA
+if conditionA:
     AddSugar()
     AddFlour()
     AddEggs()
     Mix()
 END if
 
-if conditionB
+if conditionB:
     AddSugar()
     AddFlour()
     AddEggs()
@@ -166,18 +166,18 @@ if conditionB
 END if
 
 // Do this
-function MakeMixture()
+function MakeMixture():
     AddSugar()
     AddFlour()
     AddEggs()
     Mix()
 END function
 
-if conditionA
+if conditionA:
     MakeMixture()
 END if
 
-if conditionB
+if conditionB:
     MakeMixture()
 END if
 ```
@@ -193,13 +193,13 @@ While not strictly part of the code's functionality, comments are part of the ov
 counter = 0 // Set counter to zero
 
 // Bad: Explains 'how' instead of 'why', which should be evident from the code
-function AddNumbers(a, b)
+function AddNumbers(a, b):
     // Add a and b and return the sum
     return a + b
 END function
 
 // Bad: Comment is redundant because the code is self-explanatory
-if temperature >= 100
+if temperature >= 100:
     // If temperature is greater than or equal to 100, print 'It's very hot!'
     Print("It's very hot!")
 END if
@@ -212,13 +212,13 @@ END if
 maxLoginAttempts = 3 // Limit attempts to prevent brute force attacks
 
 // Good: Describes the purpose of a complex function
-function CalculateOptimalPath()
+function CalculateOptimalPath():
     // Finds the quickest route through the network.
     ...
 END function
 
 // Good: Clarifies the reason behind a particular logic choice
-if temperature < 0
+if temperature < 0:
     // Check for sub-zero temperatures to trigger the anti-freeze protocol
     ActivateAntiFreeze()
 END if
@@ -231,7 +231,7 @@ END if
 Here’s a snippet of code where everything is jumbled together. Can you reorganize it using proper spacing and indentation?
 
 ```typescript
-function MakePizza(topping1,topping2)
+function MakePizza(topping1,topping2):
 dough = 'wheat'
 AddToPan(dough)
 AddToPan(topping1)
@@ -246,7 +246,7 @@ END function
 When making a pizza in code, just like in the kitchen, organization is key. You gather your ingredients, prepare your dough, add the toppings, and finally, bake your pizza to perfection. Let's take this step-by-step approach to our `MakePizza` function:
 
 ```typescript
-function MakePizza(topping1,topping2)
+function MakePizza(topping1,topping2):
     // Prepare the base ingredients
     dough = 'wheat'
     ovenTemp = 475
@@ -287,7 +287,7 @@ Display("Welcome, IronHeart007!")
 We want to make a function that handles the setup process for a player. This way, we can call the same function for all players without repeating those 11 (the `PRINT` as well as the 10 other lines) lines of code. Here's how you might structure that function and call it for all players:
 
 ```typescript
-function SetUpGame(player)
+function SetUpGame(player):
     Display("Welcome, " + player + "!")
     // ...
     // 10 more lines of code for setting up the game for a player
@@ -295,8 +295,8 @@ function SetUpGame(player)
 END function
 
 // Call the function for each player
-SetUpGame("playerone");
-SetUpGame("zombieXZ");
+SetUpGame("playerone")
+SetUpGame("zombieXZ")
 SetUpGame("IronHeart007")
 ```
 

--- a/programming-fundamentals/chapter9.md
+++ b/programming-fundamentals/chapter9.md
@@ -42,9 +42,9 @@ In some of the previous chapters, we've touched upon some good coding practices 
 Good naming is like giving clear, easy-to-follow instructions. When naming functions, we use verbs to describe actions, making it obvious what the function does. So is this good enough?
 
 ```typescript
-FUNCTION DoThing()
+function DoThing()
     ...
-END FUNCTION
+END function
 ```
 
 No, because what this function does just by looking at its name is anyone's guess. Now just to understand what the function does, we'd have to go inside the function and try to understand the code.
@@ -52,9 +52,9 @@ No, because what this function does just by looking at its name is anyone's gues
 Instead, you should call it something like:
 
 ```typescript
-FUNCTION CalculateTotalScore()
+function CalculateTotalScore()
     ...
-END FUNCTION
+END function
 ```
 
 Now, we're not forced to read the code inside this function to understand what it does; we can simply read its name.
@@ -78,13 +78,13 @@ How you structure and format your code can greatly influence how easy it is to r
 Just like paragraphs in a story, code needs to be organized with proper spacing and indentation to tell the computer (and our friends) what steps to follow and in what order. Indentation helps to show which pieces of code are connected. For example, everything inside a loop should be indented one level deeper:
 
 ```typescript
-FUNCTION PrepareTea(numOfGuests)
+function PrepareTea(numOfGuests)
     i = 0
-    WHILE i < numOfGuests:
+    while i < numOfGuests:
         AddWater()
         SteepTea()
-    END WHILE
-END FUNCTION
+    END while
+END function
 ```
 
 Notice how the actions inside the for loop (adding water and steeping the tea) are indented, showing they are part of the looping action.
@@ -94,7 +94,7 @@ Notice how the actions inside the for loop (adding water and steeping the tea) a
 Think of variables like ingredients in a recipe. You want to lay them all out before you start cooking. By grouping related variables at the start, you make your "recipe" easier to follow. Here's an example:
 
 ```typescript
-FUNCTION BakeCake()
+function BakeCake()
     eggs = 3
     sugar = "1 cup"
     flour = "2 cups"
@@ -102,7 +102,7 @@ FUNCTION BakeCake()
     MixIngredients(eggs, sugar, flour)
     PourBatter()
     Bake()
-END FUNCTION
+END function
 ```
 
 All the "ingredients" are listed at the top, so it's clear what we need to bake the cake.
@@ -112,15 +112,15 @@ All the "ingredients" are listed at the top, so it's clear what we need to bake 
 When writing a story, we use paragraphs to separate ideas; in coding, we use blank lines to break up our code into sections. Each part does something different, like setting up the game, playing a round, or ending the game:
 
 ```typescript
-FUNCTION PlayGame()
+function PlayGame()
     SetupGame()
 
-    WHILE not gameOver
+    while not gameOver
         PlayRound()
-    END WHILE
+    END while
     
     EndGame()
-END FUNCTION
+END function
 ```
 
 ### Avoiding Deep Nesting
@@ -129,20 +129,20 @@ When we write stories, if we have too many stories within stories, it can become
 
 ```typescript
 // Try to avoid this
-IF conditionA
-    IF conditionB
-        IF conditionC
+if conditionA
+    if conditionB
+        if conditionC
             // Code here is deeply nested 
             //and harder to read.
-        END IF
-    END IF
-END IF
+        END if
+    END if
+END if
 
 
 // Better approach
-IF conditionA AND conditionB AND conditionC
+if conditionA AND conditionB AND conditionC
     // Code here is easier to understand.
-END IF
+END if
 ```
 
 ### Using Functions to Reduce Repetition
@@ -151,35 +151,35 @@ Just like we don't want to repeat the same story over and over again, we don't w
 
 ```typescript
 // Instead of this
-IF conditionA
+if conditionA
     AddSugar()
     AddFlour()
     AddEggs()
     Mix()
-END IF
+END if
 
-IF conditionB
+if conditionB
     AddSugar()
     AddFlour()
     AddEggs()
     Mix()
-END IF
+END if
 
 // Do this
-FUNCTION MakeMixture()
+function MakeMixture()
     AddSugar()
     AddFlour()
     AddEggs()
     Mix()
-END FUNCTION
+END function
 
-IF conditionA
+if conditionA
     MakeMixture()
-END IF
+END if
 
-IF conditionB
+if conditionB
     MakeMixture()
-END IF
+END if
 ```
 
 ## Commenting Properly
@@ -193,16 +193,16 @@ While not strictly part of the code's functionality, comments are part of the ov
 counter = 0 // Set counter to zero
 
 // Bad: Explains 'how' instead of 'why', which should be evident from the code
-FUNCTION AddNumbers(a, b)
+function AddNumbers(a, b)
     // Add a and b and return the sum
-    RETURN a + b
-END FUNCTION
+    return a + b
+END function
 
 // Bad: Comment is redundant because the code is self-explanatory
-IF temperature >= 100
+if temperature >= 100
     // If temperature is greater than or equal to 100, print 'It's very hot!'
     Print("It's very hot!")
-END IF
+END if
 ```
 
 ### Good Commenting Examples
@@ -212,16 +212,16 @@ END IF
 maxLoginAttempts = 3 // Limit attempts to prevent brute force attacks
 
 // Good: Describes the purpose of a complex function
-FUNCTION CalculateOptimalPath()
+function CalculateOptimalPath()
     // Finds the quickest route through the network.
     ...
-END FUNCTION
+END function
 
 // Good: Clarifies the reason behind a particular logic choice
-IF temperature < 0
+if temperature < 0
     // Check for sub-zero temperatures to trigger the anti-freeze protocol
     ActivateAntiFreeze()
-END IF
+END if
 ```
 
 ## Activities
@@ -231,14 +231,14 @@ END IF
 Here’s a snippet of code where everything is jumbled together. Can you reorganize it using proper spacing and indentation?
 
 ```typescript
-FUNCTION MakePizza(topping1,topping2)
+function MakePizza(topping1,topping2)
 dough = 'wheat'
 AddToPan(dough)
 AddToPan(topping1)
 AddToPan(topping2)
 ovenTemp = 475
 Bake(ovenTemp)
-END FUNCTION
+END function
 ```
 
 **Answer:**
@@ -246,7 +246,7 @@ END FUNCTION
 When making a pizza in code, just like in the kitchen, organization is key. You gather your ingredients, prepare your dough, add the toppings, and finally, bake your pizza to perfection. Let's take this step-by-step approach to our `MakePizza` function:
 
 ```typescript
-FUNCTION MakePizza(topping1,topping2)
+function MakePizza(topping1,topping2)
     // Prepare the base ingredients
     dough = 'wheat'
     ovenTemp = 475
@@ -258,7 +258,7 @@ FUNCTION MakePizza(topping1,topping2)
     
     // Bake the pizza at the desired temperature
     Bake(ovenTemp)
-END FUNCTION
+END function
 ```
 
 With the ingredients and steps laid out clearly, anyone reading this code will understand the process of making a pizza. The comments provide additional context, making the function accessible even for those who might be new to coding.
@@ -287,12 +287,12 @@ Display("Welcome, IronHeart007!")
 We want to make a function that handles the setup process for a player. This way, we can call the same function for all players without repeating those 11 (the `PRINT` as well as the 10 other lines) lines of code. Here's how you might structure that function and call it for all players:
 
 ```typescript
-FUNCTION SetUpGame(player)
+function SetUpGame(player)
     Display("Welcome, " + player + "!")
     // ...
     // 10 more lines of code for setting up the game for a player
     // These might include initializing scores, setting positions, etc.
-END FUNCTION
+END function
 
 // Call the function for each player
 SetUpGame("playerone");


### PR DESCRIPTION
Purpose of this PR: Make pseudocode consistent throughout the chapters
- Add colons to function definitions, if-elseif-else statements, and while loops wherever used
- Make lowercase certain keywords such as 'if', 'else if', 'else', 'while', 'function' and 'return'.